### PR TITLE
Added .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
When generating helptags, /doc/tags gets created, which isn't tracked. Adding it to .gitignore file helps keep git repo clean when this plugin is added as submodule.
